### PR TITLE
Security bypass

### DIFF
--- a/backend/src/main/java/ropold/backend/controller/RoomController.java
+++ b/backend/src/main/java/ropold/backend/controller/RoomController.java
@@ -73,7 +73,13 @@ public class RoomController {
     @PostMapping
     public RoomModel postRoom(
             @RequestPart("roomModelDto") @Valid RoomModelDto roomModelDto,
-            @RequestPart(value = "image", required = false) MultipartFile image) throws IOException {
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            @AuthenticationPrincipal OAuth2User authentication) throws IOException {
+
+        String authenticatedUserId = authentication.getName();
+        if (!authenticatedUserId.equals(roomModelDto.appUserGithubId())) {
+            throw new AccessDeniedException("Access denied: User is not authorized to create a room on behalf of another user.");
+        }
 
         String imageUrl = null;
         if (image != null && !image.isEmpty()) {

--- a/backend/src/main/java/ropold/backend/controller/RoomController.java
+++ b/backend/src/main/java/ropold/backend/controller/RoomController.java
@@ -43,10 +43,8 @@ public class RoomController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeRoomFromFavorites(@PathVariable String roomId, @AuthenticationPrincipal OAuth2User authentication) {
         String authenticatedUserId = authentication.getName();
-
         appUserService.removeRoomFromFavorites(authenticatedUserId, roomId);
     }
-
 
     @GetMapping()
     public List<RoomModel> getAllRooms() {

--- a/backend/src/main/java/ropold/backend/controller/RoomController.java
+++ b/backend/src/main/java/ropold/backend/controller/RoomController.java
@@ -38,7 +38,7 @@ public class RoomController {
         String authenticatedUserId = authentication.getName();
 
         if (!authenticatedUserId.equals(userId)) {
-            throw new AccessDeniedException("Access denied: User is not authorized to add this room to favorites.");
+            throw new AccessDeniedException("Access denied: User" + userId + "is not authorized to add this room to favorites.");
         }
         appUserService.addRoomToFavorites(userId, roomId);
     }

--- a/backend/src/main/java/ropold/backend/controller/RoomController.java
+++ b/backend/src/main/java/ropold/backend/controller/RoomController.java
@@ -51,7 +51,7 @@ public class RoomController {
         if (!authenticatedUserId.equals(userId)) {
             throw new AccessDeniedException("Access denied: User is not authorized to delete this room from favorites.");
         }
-        appUserService.addRoomToFavorites(userId, roomId);
+        appUserService.removeRoomFromFavorites(userId, roomId);
     }
 
     @GetMapping()
@@ -139,7 +139,13 @@ public class RoomController {
 
 
     @PutMapping("/{id}/toggle-active")
-    public RoomModel toggleActiveStatus(@PathVariable String id) {
+    public RoomModel toggleActiveStatus(@PathVariable String id,@AuthenticationPrincipal OAuth2User authentication) {
+        String authenticatedUserId = authentication.getName();
+        RoomModel room = roomService.getRoomById(id);
+
+        if (!authenticatedUserId.equals(room.appUserGithubId())) {
+            throw new AccessDeniedException("Access denied: User is not authorized to toggle the active status of this room.");
+        }
        return roomService.toggleActiveStatus(id);
     }
 

--- a/backend/src/main/java/ropold/backend/controller/RoomController.java
+++ b/backend/src/main/java/ropold/backend/controller/RoomController.java
@@ -2,9 +2,13 @@ package ropold.backend.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.net.openssl.ciphers.Authentication;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 import ropold.backend.model.RoomModel;
 import ropold.backend.model.RoomModelDto;
 import ropold.backend.service.AppUserService;
@@ -31,13 +35,26 @@ public class RoomController {
 
     @PostMapping("/favorites/{userId}/{roomId}")
     @ResponseStatus(HttpStatus.CREATED)
-    public void addRoomToFavorites(@PathVariable String userId, @PathVariable String roomId) {
+    public void addRoomToFavorites(@PathVariable String userId, @PathVariable String roomId , @AuthenticationPrincipal OAuth2User authentication) {
+        String authenticatedUserId = authentication.getName();
+
+        if(!authenticatedUserId.equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+            // hier andere exception werfen
+        }
         appUserService.addRoomToFavorites(userId, roomId);
     }
 
     @DeleteMapping("/favorites/{userId}/{roomId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removeRoomFromFavorites(@PathVariable String userId, @PathVariable String roomId) {
+    public void removeRoomFromFavorites(@PathVariable String userId, @PathVariable String roomId, @AuthenticationPrincipal OAuth2User authentication) {
+        String authenticatedUserId = authentication.getName();
+
+        if(!authenticatedUserId.equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+            // hier andere exception werfen
+        }
+
         appUserService.removeRoomFromFavorites(userId, roomId);
     }
 

--- a/backend/src/main/java/ropold/backend/controller/RoomController.java
+++ b/backend/src/main/java/ropold/backend/controller/RoomController.java
@@ -26,33 +26,27 @@ public class RoomController {
     private final CloudinaryService cloudinaryService;
     private final AppUserService appUserService;
 
-    @GetMapping("/favorites/{userId}")
-    public List<RoomModel> getUserFavorites(@PathVariable String userId) {
-        List<String> favoriteRoomIds = appUserService.getUserFavorites(userId);
+    @GetMapping("/favorites")
+    public List<RoomModel> getUserFavorites(@AuthenticationPrincipal OAuth2User authentication) {
+        List<String> favoriteRoomIds = appUserService.getUserFavorites(authentication.getName());
         return roomService.getRoomsByIds(favoriteRoomIds);
     }
 
-    @PostMapping("/favorites/{userId}/{roomId}")
+    @PostMapping("/favorites/{roomId}")
     @ResponseStatus(HttpStatus.CREATED)
-    public void addRoomToFavorites(@PathVariable String userId, @PathVariable String roomId , @AuthenticationPrincipal OAuth2User authentication) {
+    public void addRoomToFavorites(@PathVariable String roomId , @AuthenticationPrincipal OAuth2User authentication) {
         String authenticatedUserId = authentication.getName();
-
-        if (!authenticatedUserId.equals(userId)) {
-            throw new AccessDeniedException("Access denied: User" + userId + "is not authorized to add this room to favorites.");
-        }
-        appUserService.addRoomToFavorites(userId, roomId);
+        appUserService.addRoomToFavorites(authenticatedUserId, roomId);
     }
 
-    @DeleteMapping("/favorites/{userId}/{roomId}")
+    @DeleteMapping("/favorites/{roomId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removeRoomFromFavorites(@PathVariable String userId, @PathVariable String roomId, @AuthenticationPrincipal OAuth2User authentication) {
+    public void removeRoomFromFavorites(@PathVariable String roomId, @AuthenticationPrincipal OAuth2User authentication) {
         String authenticatedUserId = authentication.getName();
 
-        if (!authenticatedUserId.equals(userId)) {
-            throw new AccessDeniedException("Access denied: User is not authorized to delete this room from favorites.");
-        }
-        appUserService.removeRoomFromFavorites(userId, roomId);
+        appUserService.removeRoomFromFavorites(authenticatedUserId, roomId);
     }
+
 
     @GetMapping()
     public List<RoomModel> getAllRooms() {
@@ -142,7 +136,6 @@ public class RoomController {
 
         return roomService.updateRoomWithPut(id, updatedRoom);
     }
-
 
     @PutMapping("/{id}/toggle-active")
     public RoomModel toggleActiveStatus(@PathVariable String id,@AuthenticationPrincipal OAuth2User authentication) {

--- a/backend/src/main/java/ropold/backend/controller/RoomController.java
+++ b/backend/src/main/java/ropold/backend/controller/RoomController.java
@@ -153,8 +153,6 @@ public class RoomController {
         if (!authenticatedUserId.equals(room.appUserGithubId())) {
             throw new AccessDeniedException("Access denied: User is not authorized to delete this room.");
         }
-
         roomService.deleteRoom(id);
     }
-
 }

--- a/backend/src/main/java/ropold/backend/exception/AccessDeniedError.java
+++ b/backend/src/main/java/ropold/backend/exception/AccessDeniedError.java
@@ -1,0 +1,6 @@
+package ropold.backend.exception;
+
+public record AccessDeniedError(
+        String message
+) {
+}

--- a/backend/src/main/java/ropold/backend/exception/AccessDeniedException.java
+++ b/backend/src/main/java/ropold/backend/exception/AccessDeniedException.java
@@ -1,0 +1,8 @@
+package ropold.backend.exception;
+
+public class AccessDeniedException extends RuntimeException {
+
+    public AccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/ropold/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ropold/backend/exception/GlobalExceptionHandler.java
@@ -25,6 +25,13 @@ public class GlobalExceptionHandler {
         return new RoomError(e.getMessage());
     }
 
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public AccessDeniedError handleAccessDeniedException(AccessDeniedException e) {
+        return new AccessDeniedError(e.getMessage()); // Fehlermeldung aus der Exception
+    }
+
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Map<String, String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {

--- a/backend/src/main/java/ropold/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/ropold/backend/security/SecurityConfig.java
@@ -46,6 +46,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, PRACTICE_HUB_PATH).authenticated() // Verwendung der Konstante
                         .requestMatchers("/api/practice-hub").authenticated()
                         .requestMatchers("/api/users/me").permitAll()
+                        .requestMatchers(HttpMethod.POST, "api/practice-hub/favorites/{userId}/{roomId}").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "api/practice-hub/favorites/{userId}/{roomId}").authenticated()
                         .anyRequest().permitAll()
                 )
                 .logout(l -> l.logoutUrl("/api/users/logout")

--- a/backend/src/main/java/ropold/backend/security/UserController.java
+++ b/backend/src/main/java/ropold/backend/security/UserController.java
@@ -7,7 +7,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import ropold.backend.repository.AppUserRepository;
 
 import java.util.Map;
 
@@ -15,8 +14,6 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/users")
 public class UserController {
-
-    private final AppUserRepository appUserRepository;
 
     @GetMapping(value = "/me", produces = "text/plain")
     public String getMe() {

--- a/backend/src/main/java/ropold/backend/service/AppUserService.java
+++ b/backend/src/main/java/ropold/backend/service/AppUserService.java
@@ -40,5 +40,4 @@ public class AppUserService {
             appUserRepository.save(user);
         }
     }
-
 }

--- a/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
+++ b/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
@@ -137,7 +137,6 @@ class RoomControllerIntegrationTest {
         Assertions.assertTrue(updatedUser.favorites().contains("2"));
     }
 
-
     @Test
     void removeRoomFromFavorites_expectNoContent_whenRoomRemoved() throws Exception {
         // GIVEN

--- a/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
+++ b/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
@@ -128,11 +128,8 @@ class RoomControllerIntegrationTest {
     void addRoomToFavorites2_shouldAddRoomToFavoritesAndReturnCreated() throws Exception {
         // Verwenden von .with(oidcLogin()) anstelle von Mocking
         mockMvc.perform(MockMvcRequestBuilders.post("/api/practice-hub/favorites/123/2")
-                        .with(oidcLogin().userInfoToken(token -> token
-                                .claim("sub", "123")  // User-ID im Token
-                                .claim("login", "testUser")
-                                .claim("avatar_url", "testAvatarUrl")
-                        )))
+                        .with(oidcLogin().idToken(i -> i.claim("sub", "123")))
+                                )
                 .andExpect(status().isCreated());  // Erwartet den Status "201 Created"
 
         // Überprüfung, dass der Raum in die Favoritenliste des Benutzers hinzugefügt wurde

--- a/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
+++ b/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
@@ -213,9 +213,18 @@ class RoomControllerIntegrationTest {
     }
 
     @Test
-    @WithMockUser(username = "123")
     void postRoom_shouldReturnSavedRoom() throws Exception {
         // GIVEN
+
+        OAuth2User mockOAuth2User = mock(OAuth2User.class);
+        when(mockOAuth2User.getName()).thenReturn("123");  // The name of the authenticated user
+
+        // Set the Mock OAuth2User in the SecurityContext and mark it as authenticated
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockOAuth2User, null,
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
         roomRepository.deleteAll();
         Uploader mockUploader = mock(Uploader.class);
         when(mockUploader.upload(any(), anyMap())).thenReturn(Map.of("secure_url", "https://www.test.de/"));

--- a/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
+++ b/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -119,6 +120,22 @@ class RoomControllerIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/api/practice-hub/favorites/123/2"))
                 .andExpect(status().isCreated());  // Expecting the "201 Created" status
 
+        AppUser updatedUser = appUserRepository.findById("123").orElseThrow();
+        Assertions.assertTrue(updatedUser.favorites().contains("2"));
+    }
+
+    @Test
+    void addRoomToFavorites2_shouldAddRoomToFavoritesAndReturnCreated() throws Exception {
+        // Verwenden von .with(oidcLogin()) anstelle von Mocking
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/practice-hub/favorites/123/2")
+                        .with(oidcLogin().userInfoToken(token -> token
+                                .claim("sub", "123")  // User-ID im Token
+                                .claim("login", "testUser")
+                                .claim("avatar_url", "testAvatarUrl")
+                        )))
+                .andExpect(status().isCreated());  // Erwartet den Status "201 Created"
+
+        // Überprüfung, dass der Raum in die Favoritenliste des Benutzers hinzugefügt wurde
         AppUser updatedUser = appUserRepository.findById("123").orElseThrow();
         Assertions.assertTrue(updatedUser.favorites().contains("2"));
     }

--- a/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
+++ b/backend/src/test/java/ropold/backend/controller/RoomControllerIntegrationTest.java
@@ -10,6 +10,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -19,6 +23,7 @@ import ropold.backend.model.RoomModel;
 import ropold.backend.repository.AppUserRepository;
 import ropold.backend.repository.RoomRepository;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -100,21 +105,38 @@ class RoomControllerIntegrationTest {
     }
 
     @Test
-    @WithMockUser(username = "123")
     void addRoomToFavorites_shouldAddRoomToFavoritesAndReturnCreated() throws Exception {
-        // GIVEN Room with ID "2" exists // WHEN:
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/practice-hub/favorites/123/2"))
-                .andExpect(status().isCreated());
+        // Mock OAuth2User
+        OAuth2User mockOAuth2User = mock(OAuth2User.class);
+        when(mockOAuth2User.getName()).thenReturn("123");  // The name of the authenticated user
 
-        // THEN:
+        // Set the Mock OAuth2User in the SecurityContext and mark it as authenticated
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockOAuth2User, null,
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/practice-hub/favorites/123/2"))
+                .andExpect(status().isCreated());  // Expecting the "201 Created" status
+
         AppUser updatedUser = appUserRepository.findById("123").orElseThrow();
         Assertions.assertTrue(updatedUser.favorites().contains("2"));
     }
 
+
     @Test
-    @WithMockUser(username = "123")
     void removeRoomFromFavorites_expectNoContent_whenRoomRemoved() throws Exception {
         // GIVEN
+
+        OAuth2User mockOAuth2User = mock(OAuth2User.class);
+        when(mockOAuth2User.getName()).thenReturn("123");  // The name of the authenticated user
+
+        // Set the Mock OAuth2User in the SecurityContext and mark it as authenticated
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockOAuth2User, null,
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
         AppUser user = appUserRepository.findById("123").orElseThrow();
         List<String> favoritesBefore = user.favorites();
         Assertions.assertTrue(favoritesBefore.contains("1"));
@@ -240,9 +262,18 @@ class RoomControllerIntegrationTest {
     }
 
     @Test
-    @WithMockUser(username = "123")
     void updateRoomWithPut_shouldUpdateRoomDetails() throws Exception {
         // GIVEN
+
+        OAuth2User mockOAuth2User = mock(OAuth2User.class);
+        when(mockOAuth2User.getName()).thenReturn("123");  // The name of the authenticated user
+
+        // Set the Mock OAuth2User in the SecurityContext and mark it as authenticated
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockOAuth2User, null,
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
         RoomModel existingRoom = new RoomModel("1", "Gürzenich Saal", "Martinstr. 29 50667 Köln",
                 Category.ORCHESTER_HALL, "Ein traditionsreicher Saal für Konzerte und Veranstaltungen.",
                 "123", "TestUser", "https://avatars-of-test-user.com/",
@@ -297,9 +328,18 @@ class RoomControllerIntegrationTest {
     }
 
     @Test
-    @WithMockUser(username = "testUser", roles = {"USER"})
     void deleteRoom_shouldRemoveRoomFromRepository() throws Exception {
         // GIVEN
+
+        OAuth2User mockOAuth2User = mock(OAuth2User.class);
+        when(mockOAuth2User.getName()).thenReturn("123");  // The name of the authenticated user
+
+        // Set the Mock OAuth2User in the SecurityContext and mark it as authenticated
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockOAuth2User, null,
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
         RoomModel roomToDelete = new RoomModel("2", "Beethoven-Saal", "Beethovenstraße 1, 53115 Bonn",
                 Category.ORCHESTER_HALL, "Ein moderner Saal für klassische Musik und Veranstaltungen.",
                 "123", "Testuser", "https://avatars-of-test-user.com/",

--- a/backend/src/test/java/ropold/backend/exception/ExceptionHandlerTest.java
+++ b/backend/src/test/java/ropold/backend/exception/ExceptionHandlerTest.java
@@ -8,17 +8,26 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import ropold.backend.repository.RoomRepository;
+import ropold.backend.service.AppUserService;
+import static org.hamcrest.Matchers.is;
 
+
+import java.util.Collections;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -33,6 +42,33 @@ class ExceptionHandlerTest {
 
     @MockBean
     private Cloudinary cloudinary;
+
+    @MockBean
+    private AppUserService appUserService;
+
+    @Test
+    @WithMockUser(username = "user1") // Simuliert einen authentifizierten Benutzer
+    void whenAccessDeniedExceptionThrown_thenReturnForbiddenResponse() throws Exception {
+        // Simuliert, dass die Methode 'removeRoomFromFavorites' eine AccessDeniedException wirft
+
+        OAuth2User mockOAuth2User = mock(OAuth2User.class);
+        when(mockOAuth2User.getName()).thenReturn("123");  // The name of the authenticated user
+
+        // Set the Mock OAuth2User in the SecurityContext and mark it as authenticated
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockOAuth2User, null,
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
+        doThrow(new AccessDeniedException("Access denied: User is not authorized to delete this room from favorites."))
+                .when(appUserService).removeRoomFromFavorites("user1", "room1");
+
+        // Simuliere eine DELETE-Anfrage, die die Ausnahme auslöst
+        mockMvc.perform(delete("/api/practice-hub/favorites/user1/room1"))
+                .andExpect(status().isForbidden()) // Überprüfe, ob der Status 403 (Forbidden) zurückgegeben wird
+                .andExpect(jsonPath("$.message", is("Access denied: User is not authorized to delete this room from favorites."))) // Überprüfe, ob die Fehlermeldung korrekt ist
+                .andReturn();
+    }
 
     @Test
     void whenRoomNotFoundException_thenReturnsNotFound() throws Exception {

--- a/backend/src/test/java/ropold/backend/exception/ExceptionHandlerTest.java
+++ b/backend/src/test/java/ropold/backend/exception/ExceptionHandlerTest.java
@@ -16,8 +16,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import ropold.backend.model.Category;
-import ropold.backend.model.RoomModelDto;
 import ropold.backend.repository.RoomRepository;
 import ropold.backend.service.AppUserService;
 import static org.hamcrest.Matchers.is;
@@ -117,11 +115,6 @@ class ExceptionHandlerTest {
     @WithMockUser(username = "user123") // Simuliert einen authentifizierten Benutzer mit einer bestimmten ID
     void postRoom_shouldReturnAccessDenied_whenUserIsNotAuthorized() throws Exception {
         // GIVEN: Ein Raum, der von einem anderen Benutzer erstellt werden soll
-        RoomModelDto roomModelDto = new RoomModelDto(
-                "Room Name", "Room Address", Category.BAND_ROOM, "Room Description",
-                "otherUserGithubId", "Other User", "https://avatars.githubusercontent.com/u/otherUser?v=4",
-                "https://github.com/otherUser", true, "https://res.cloudinary.com/otherUser/image.jpg"
-        );
 
         // Simuliere, dass der authentifizierte Benutzer nicht mit dem GitHub-Id im roomModelDto übereinstimmt
         OAuth2User mockOAuth2User = mock(OAuth2User.class);

--- a/backend/src/test/java/ropold/backend/exception/ExceptionHandlerTest.java
+++ b/backend/src/test/java/ropold/backend/exception/ExceptionHandlerTest.java
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import ropold.backend.repository.RoomRepository;
-import ropold.backend.service.AppUserService;
 import static org.hamcrest.Matchers.is;
 
 
@@ -27,7 +26,6 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -42,33 +40,6 @@ class ExceptionHandlerTest {
 
     @MockBean
     private Cloudinary cloudinary;
-
-    @MockBean
-    private AppUserService appUserService;
-
-    @Test
-    @WithMockUser(username = "user1") // Simuliert einen authentifizierten Benutzer
-    void whenAccessDeniedExceptionThrown_thenReturnForbiddenResponse() throws Exception {
-        // Simuliert, dass die Methode 'removeRoomFromFavorites' eine AccessDeniedException wirft
-
-        OAuth2User mockOAuth2User = mock(OAuth2User.class);
-        when(mockOAuth2User.getName()).thenReturn("123");  // The name of the authenticated user
-
-        // Set the Mock OAuth2User in the SecurityContext and mark it as authenticated
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(mockOAuth2User, null,
-                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
-        );
-
-        doThrow(new AccessDeniedException("Access denied: User is not authorized to delete this room from favorites."))
-                .when(appUserService).removeRoomFromFavorites("user1", "room1");
-
-        // Simuliere eine DELETE-Anfrage, die die Ausnahme auslöst
-        mockMvc.perform(delete("/api/practice-hub/favorites/user1/room1"))
-                .andExpect(status().isForbidden()) // Überprüfe, ob der Status 403 (Forbidden) zurückgegeben wird
-                .andExpect(jsonPath("$.message", is("Access denied: User is not authorized to delete this room from favorites."))) // Überprüfe, ob die Fehlermeldung korrekt ist
-                .andReturn();
-    }
 
     @Test
     void whenRoomNotFoundException_thenReturnsNotFound() throws Exception {

--- a/backend/src/test/java/ropold/backend/exception/ExceptionHandlerTest.java
+++ b/backend/src/test/java/ropold/backend/exception/ExceptionHandlerTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import ropold.backend.repository.RoomRepository;
 import static org.hamcrest.Matchers.is;
 
-
 import java.util.Collections;
 import java.util.Map;
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,7 @@ export default function App() {
     function getUserDetails() {
         axios.get("/api/users/me/details")
             .then((response) => {
-                console.log("User details:", response.data);
+                //console.log("User details:", response.data);
                 setUserDetails(response.data);
             })
             .catch((error) => {
@@ -55,7 +55,7 @@ export default function App() {
     }
 
     function getAppUserFavorites(){
-        axios.get(`/api/practice-hub/favorites/${user}`)
+        axios.get(`/api/practice-hub/favorites`)
             .then((response) => {
                 const favoriteIds = response.data.map((favorite: any) => favorite.id);
                 setFavorites(favoriteIds);
@@ -91,7 +91,7 @@ export default function App() {
         const isFavorite = favorites.includes(roomId);
 
         if (isFavorite) {
-            axios.delete(`/api/practice-hub/favorites/${user}/${roomId}`)
+            axios.delete(`/api/practice-hub/favorites/${roomId}`)
                 .then(() => {
                     setFavorites((prevFavorites) =>
                         prevFavorites.filter((id) => id !== roomId)
@@ -99,7 +99,7 @@ export default function App() {
                 })
                 .catch((error) => console.error(error));
         } else {
-            axios.post(`/api/practice-hub/favorites/${user}/${roomId}`)
+            axios.post(`/api/practice-hub/favorites/${roomId}`)
                 .then(() => {
                     setFavorites((prevFavorites) => [...prevFavorites, roomId]);
                 })
@@ -138,10 +138,10 @@ export default function App() {
                 <Route path="/room/:id" element={<Details favorites={favorites} user={user} toggleFavorite={toggleFavorite} />} />
                 <Route path="/mapbox-all" element={<MapBoxAll favorites={favorites} activeRooms={activeRooms} toggleFavorite={toggleFavorite}/>} />
                 <Route element={<ProtectedRoute user={user} />}>
-                    <Route path="/:id/favorites/" element={<Favorites favorites={favorites} user={user} toggleFavorite={toggleFavorite}/>} />
-                    <Route path={"/:id/my-rooms/"} element={<MyRooms favorites={favorites} user={user} toggleFavorite={toggleFavorite} rooms={rooms} userDetails={userDetails} setRooms={setRooms}/>} />
-                    <Route path={"/:id/add-room/"} element={<AddRoom user={user} handleSubmit={handleNewRoomSubmit} userDetails={userDetails}/>} />
-                    <Route path={"/:id/profile"} element={<Profile userDetails={userDetails}/>} />
+                    <Route path="/favorites/" element={<Favorites favorites={favorites} user={user} toggleFavorite={toggleFavorite}/>} />
+                    <Route path={"/my-rooms/"} element={<MyRooms favorites={favorites} user={user} toggleFavorite={toggleFavorite} rooms={rooms} userDetails={userDetails} setRooms={setRooms}/>} />
+                    <Route path={"/add-room/"} element={<AddRoom user={user} handleSubmit={handleNewRoomSubmit} userDetails={userDetails}/>} />
+                    <Route path={"/profile"} element={<Profile userDetails={userDetails}/>} />
                 </Route>
             </Routes>
             <Footer/>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,7 @@ export default function App() {
     function getUserDetails() {
         axios.get("/api/users/me/details")
             .then((response) => {
-                //console.log("User details:", response.data);
+                console.log("User details:", response.data);
                 setUserDetails(response.data);
             })
             .catch((error) => {

--- a/frontend/src/components/Favorites.tsx
+++ b/frontend/src/components/Favorites.tsx
@@ -14,7 +14,7 @@ export default function Favorites(props: Readonly<FavoritesProps>) {
 
     useEffect(() => {
         axios
-            .get(`/api/practice-hub/favorites/${props.user}`)
+            .get(`/api/practice-hub/favorites`)
             .then((response) => {
                 setFavoritesRooms(response.data);
             })

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -64,14 +64,14 @@ export default function NavBar(props: Readonly<NavbarProps>) {
 
             {props.user !== "anonymousUser" ? (
                 <>
-                    <button onClick={() => navigate(`/${props.user}/favorites`)}>Favorites</button>
-                    <button onClick={() => navigate(`/${props.user}/add-room`)}>Add Room</button>
+                    <button onClick={() => navigate(`/favorites`)}>Favorites</button>
+                    <button onClick={() => navigate(`/add-room`)}>Add Room</button>
                     <button onClick={() => {
                         props.getAllRooms();
-                        navigate(`/${props.user}/my-rooms`)
+                        navigate(`/my-rooms`)
                     }}>My Rooms
                     </button>
-                    <button onClick={() => navigate(`/${props.user}/profile`)}>Profile</button>
+                    <button onClick={() => navigate(`/profile`)}>Profile</button>
                     <button onClick={logoutFromGithub}>Logout</button>
                 </>
             ) : (


### PR DESCRIPTION
Controller OAuth2User authentication for:
- addRoomToFavorites
- removeRoomFromFavorites
- postRoom
- putRoom
- toggleActiveStatus
- deleteRoom

Adjust in the RoomControllerIntegrationTest for these five Methods:
- mock the OAuth2User

Added Tests in RoomControllerIntegrationTest with(oidcLogin()) instead of Mocking:
- getActiveRooms_shouldReturnActiveRooms
- toggleActiveStatus_shouldToggleActiveStatus_whenAuthorized
- toggleActiveStatus_shouldReturnAccessDenied_whenUserNotOwner

Added to E-Handler
- AccessDeniedException

E-Handlertests added:
- whenAccessDeniedExceptionThrown_thenReturnForbiddenResponse
- postRoom_shouldReturnAccessDenied_whenUserIsNotAuthorized
